### PR TITLE
Use logging library for output

### DIFF
--- a/library.dylan
+++ b/library.dylan
@@ -5,6 +5,7 @@ define library dylan-tool
   use io,
     import: { format, standard-io, streams };
   use json;
+  use logging;
   use pacman;
   use regular-expressions;
   use strings;
@@ -34,6 +35,7 @@ define module dylan-tool
               merge-locators,
               relative-locator,
               subdirectory-locator };
+  use logging;
   use operating-system,
     prefix: "os/",
     rename: { run-application => os/run };

--- a/pkg.json
+++ b/pkg.json
@@ -2,6 +2,7 @@
     "name": "dylan-tool",
     "deps": [ "command-line-parser head",
               "json head",
+              "logging head",
               "pacman head",
               "regular-expressions head",
               "uncommon-dylan head",


### PR DESCRIPTION
`dylan-tool` sets the log level to `trace` when the `--verbose` flag is used. The `dylan-tool`, `pacman`, and `workspaces` libraries use `log-trace` for verbose output.