### PR TITLE
Add a GitHub workflow to run tests

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,10 +2,14 @@ name: Makefile CI
 
 on:
   push:
-    branches: [ github-ci ]
+    branches:
+      - github-ci
+      - master
   pull_request:
-    branches: [ github-ci ]
-  # This enables the Run Workflow button on the Actions tab.
+    branches:
+      - github-ci
+      - master
+  # This enables the Run Workflow button on the Actions tab. (Or does it?)
   workflow_dispatch:
 
 jobs:
@@ -18,16 +22,6 @@ jobs:
       with:
         submodules: recursive
 
-    - name: debug
-      run: |
-        ls -l
-        find .
-
-#    - name: Checkout json
-#      uses: actions/checkout@v2
-#      with:
-#        repository: dylan-lang/json
-
     - name: Install Open Dylan
       run: |
           echo "Installing Open Dylan..."
@@ -36,5 +30,20 @@ jobs:
           echo -n "This is Open Dylan "
           opendylan-2020.1/bin/dylan-compiler -version
 
+    # Build and run test suites as individual steps rather than just using
+    # `make test`, so we get better feedback in the GitHub UI.
+
     - name: Build dylan-tool
-      run: PATH=opendylan-2020.1/bin:$PATH make test
+      run: opendylan-2020.1/bin/dylan-compiler -build -jobs 3 dylan-tool
+
+    - name: Build pacman-test-suite
+      run: opendylan-2020.1/bin/dylan-compiler -build -jobs 3 pacman-test-suite
+
+    - name: Run pacman-test-suite
+      run: _build/bin/pacman-test-suite
+
+    - name: Build workspaces-test-suite
+      run: opendylan-2020.1/bin/dylan-compiler -build -jobs 3 workspaces-test-suite
+
+    - name: Run workspaces-test-suite
+      run: _build/bin/workspaces-test-suite

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -37,4 +37,4 @@ jobs:
           opendylan-2020.1/bin/dylan-compiler -version
 
     - name: Build dylan-tool
-      run: PATH=opendylan-2020.1/bin:$PATH make test-with-submodules
+      run: PATH=opendylan-2020.1/bin:$PATH make test

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,40 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ github-ci ]
+  pull_request:
+    branches: [ github-ci ]
+  # This enables the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: debug
+      run: |
+        ls -l
+        find .
+
+#    - name: Checkout json
+#      uses: actions/checkout@v2
+#      with:
+#        repository: dylan-lang/json
+
+    - name: Install Open Dylan
+      run: |
+          echo "Installing Open Dylan..."
+          curl -L -o opendylan.tar.bz2 https://github.com/dylan-lang/opendylan/releases/download/v2020.1.0/opendylan-2020.1-x86_64-linux.tar.bz2
+          tar xfj opendylan.tar.bz2
+          echo -n "This is Open Dylan "
+          opendylan-2020.1/bin/dylan-compiler -version
+
+    - name: Build dylan-tool
+      run: PATH=opendylan-2020.1/bin:$PATH make test-with-submodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "ext/pacman-catalog"]
 	path = ext/pacman-catalog
 	url = https://github.com/dylan-lang/pacman-catalog
+[submodule "ext/testworks"]
+	path = ext/testworks
+	url = https://github.com/dylan-lang/testworks

--- a/Makefile
+++ b/Makefile
@@ -41,23 +41,11 @@ install: build
 # new platforms without having to manually install deps. It's easy to forget to
 # test it both ways, hence this target. (We should be able to ditch submodules
 # after there's a stable 1.0 version available for bootstrapping.)
-test: test-with-submodules test-with-packages
-
-test-with-submodules:
+test: build
 	dylan-compiler -build pacman-test-suite && _build/bin/pacman-test-suite
 	dylan-compiler -build pacman-catalog-test-suite \
 	  && DYLAN_CATALOG=ext/pacman-catalog _build/bin/pacman-catalog-test-suite
 	dylan-compiler -build workspaces-test-suite && _build/bin/workspaces-test-suite
-
-# Note that whereas test-with-submodules tests the submoduled catalog this
-# tests the installed catalog since we don't know if pacman-catalog is an
-# active package or not.
-test-with-packages: build
-	_build/bin/dylan-tool update
-	cd .. && dylan-compiler -build pacman-test-suite && _build/bin/pacman-test-suite
-	cd .. && dylan-compiler -build pacman-catalog-test-suite \
-	  && _build/bin/pacman-catalog-test-suite
-	cd .. && dylan-compiler -build workspaces-test-suite && _build/bin/workspaces-test-suite
 
 clean:
 	rm -rf _build
@@ -65,3 +53,19 @@ clean:
 distclean: clean
 	rm -rf $(install_dir)
 	rm -f $(link_source)
+
+pkg-build:
+	cd .. && dylan-compiler -build dylan-tool
+
+# Note that whereas test-with-submodules tests the submoduled catalog this
+# tests the installed catalog since we don't know if pacman-catalog is an
+# active package or not.
+pkg-test: pkg-build
+	../_build/bin/dylan-tool update
+	cd .. && dylan-compiler -build pacman-test-suite && _build/bin/pacman-test-suite
+	cd .. && dylan-compiler -build pacman-catalog-test-suite \
+	  && _build/bin/pacman-catalog-test-suite
+	cd .. && dylan-compiler -build workspaces-test-suite && _build/bin/workspaces-test-suite
+
+pkg-clean:
+	rm -rf ../_build

--- a/registry/generic/command-line-parser-test-suite
+++ b/registry/generic/command-line-parser-test-suite
@@ -1,0 +1,1 @@
+abstract://dylan/ext/command-line-parser/tests/command-line-parser-test-suite.lid

--- a/registry/generic/command-line-parser-test-suite-app
+++ b/registry/generic/command-line-parser-test-suite-app
@@ -1,0 +1,1 @@
+abstract://dylan/ext/command-line-parser/tests/command-line-parser-test-suite-app.lid

--- a/registry/generic/testworks
+++ b/registry/generic/testworks
@@ -1,0 +1,1 @@
+abstract://dylan/ext/testworks/testworks.lid

--- a/registry/generic/testworks-test-suite
+++ b/registry/generic/testworks-test-suite
@@ -1,0 +1,1 @@
+abstract://dylan/ext/testworks/tests/testworks-test-suite.lid

--- a/registry/generic/testworks-test-suite-app
+++ b/registry/generic/testworks-test-suite-app
@@ -1,0 +1,1 @@
+abstract://dylan/ext/testworks/tests/testworks-test-suite-app.lid


### PR DESCRIPTION
* Add a GitHub workflow to run tests.
* Add testworks as a submodule rather than depending on the version in whatever version of OD someone is using.