### PR TITLE
Add current git version to help output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,14 @@ link_target     = $(install_bin)/dylan-tool
 link_source     = $(DYLAN)/bin/dylan
 
 build:
-	dylan-compiler -build dylan-tool
+	file="commands/utils.dylan"; \
+	orig=$$(tempfile); \
+	temp=$$(tempfile); \
+	cp -p $${file} $${orig}; \
+	cat $${file} | sed "s,/.__./.*/.__./,/*__*/ \"$$(git describe --tags)\" /*__*/,g" > $${temp}; \
+	mv $${temp} $${file}; \
+	dylan-compiler -build dylan-tool; \
+	cp -p $${orig} $${file}
 
 # After the next OD release this should install a static exe built with the
 # -unify flag.

--- a/commands/command-line.dylan
+++ b/commands/command-line.dylan
@@ -11,7 +11,9 @@ end;
 define function dylan-tool-command-line
     () => (p :: <command-line-parser>)
   make(<command-line-parser>,
-       help: "Tool to maintain Dylan dev workspaces and installed packages.",
+       help: format-to-string("Maintain Dylan dev workspaces and installed packages.\n"
+                                "(Version: %s)\n",
+                              $dylan-tool-version),
        options: list(make(<flag-option>,
                           name: "verbose",
                           help: "Generate more verbose output."),

--- a/commands/utils.dylan
+++ b/commands/utils.dylan
@@ -2,6 +2,15 @@ Module: dylan-tool-commands
 Synopsis: Utilities for use by dylan-tool commands
 
 
+
+// The Makefile replaces this string with the actual tagged version before
+// building. DON'T MOVE THE /*__*/ MARKERS since they're part of the regex.
+// Using the comment markers enables recovery if someone commits a string
+// other than "HEAD" by accident. git's `ident` attribute doesn't use tag
+// names and `filter` looks more complex than it's worth.
+define constant $dylan-tool-version :: <string> = /*__*/ "HEAD" /*__*/;
+
+
 // Run an executable or shell command. `command` may be a string or a sequence
 // of strings. If a string it is run with `/bin/sh -c`. If a sequence of
 // strings the first element is the executable pathname. Returns the exit


### PR DESCRIPTION
Although git has the `ident` attribute to substitute the commit hash, we want
the current tag-relative name so we use Makefile hackery instead.