### PR TITLE
Add initial version of the 'publish' subcommand

### DIFF
--- a/commands/command-line.dylan
+++ b/commands/command-line.dylan
@@ -25,5 +25,6 @@ define function dylan-tool-command-line
                    subcommands: list($new-library-subcommand,
                                      $new-workspace-subcommand)),
               $update-subcommand,
-              $status-subcommand))
+              $status-subcommand,
+              $publish-subcommand))
 end function;

--- a/commands/dylan-tool-commands.lid
+++ b/commands/dylan-tool-commands.lid
@@ -11,4 +11,5 @@ Files: library.dylan
        utils.dylan
        simple-commands.dylan
        new-library.dylan
+       publish.dylan
        command-line.dylan

--- a/commands/library.dylan
+++ b/commands/library.dylan
@@ -68,6 +68,7 @@ define module pacman
     release-url,
     release-to-string,
     release-version,
+    publish-release,
 
     <dep>,
     <dep-vector>,
@@ -245,6 +246,7 @@ define module dylan-tool-commands
     prefix: "fs/";
   use format,
     import: { format, format-to-string };
+  use format-out;
   use json,
     import: { parse-json => json/parse };
   use locators,

--- a/commands/publish.dylan
+++ b/commands/publish.dylan
@@ -1,0 +1,64 @@
+Module: dylan-tool-commands
+Synopsis: The `dylan publish` command publishes a package to the catalog.
+
+
+define class <publish-subcommand> (<subcommand>)
+  keyword name = "publish";
+  keyword help = "Publish a new package release to the catalog.";
+end class;
+
+define constant $publish-subcommand
+  = make(<publish-subcommand>,
+         options:
+           list(make(<positional-option>,
+                     names: #("package"),
+                     variable: "PKG",
+                     help: "Name of the package for which to publish a release.")));
+
+define method execute-subcommand
+    (parser :: <command-line-parser>, subcmd :: <publish-subcommand>)
+ => (status :: false-or(<int>))
+  let workspace = ws/load-workspace();
+  let name = get-option-value(subcmd, "package");
+  let active-packages = ws/workspace-active-packages(workspace);
+  let publish-release
+    = find-element(active-packages,
+                   method (rel)
+                     istr=(pm/package-name(rel), name)
+                   end);
+  let catalog-release
+    = find-element(active-packages,
+                   method (rel)
+                     istr=(pm/package-name(rel), "pacman-catalog")
+                   end);
+  if (~publish-release)
+    format-out("Package %= is not an active package.\n", name);
+    1
+  elseif (~catalog-release)
+    let ws-dir = ws/workspace-directory(ws/load-workspace());
+    format-out(#:string:'
+"pacman-catalog" is not an active package in this workspace.  For now, the way
+packages are published is by making a pull request to the "pacman-catalog"
+repository. This command will make the necessary changes for you, but you must
+clone pacman-catalog first, using these commands:
+
+  cd %s
+  git clone https://github.com/dylan-lang/pacman-catalog
+  cd pacman-catalog
+  git checkout -t -b publish
+
+Then re-run this command. Once the changes have been made, commit them and submit
+a pull request. The GitHub continuous integration will verify the changes for you.
+', ws-dir);
+    1
+  else
+    // Looks good, let's publish...
+    let release = pm/load-dylan-package-file(ws/active-package-file(workspace, name));
+    os/environment-variable("DYLAN_CATALOG")
+      := as(<byte-string>,
+            ws/active-package-directory(workspace, pm/package-name(catalog-release)));
+    let catalog = pm/catalog();
+    pm/publish-release(catalog, release);
+    0
+  end
+end method;

--- a/commands/simple-commands.dylan
+++ b/commands/simple-commands.dylan
@@ -141,7 +141,7 @@ define constant $status-subcommand
 define method execute-subcommand
     (parser :: <command-line-parser>, subcmd :: <status-subcommand>)
  => (status :: false-or(<int>))
-  let workspace = ws/load-workspace(fs/working-directory());
+  let workspace = ws/load-workspace();
   if (~workspace)
     log-info("Not currently in a workspace.");
     abort-command(1);

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -136,10 +136,51 @@ Options:
    single: dependencies
    single: workspace.json file
 
+.. index::
+   single: dylan publish subcommand
+   single: subcommand; dylan publish
+
+dylan publish
+-------------
+
+The `publish` command adds a new release of a package to the package
+catalog.
+
+Synopsis: ``dylan publish <package-name>``
+
+.. note:: For now, until a fully automated solution is implemented, it works by
+          modifying the local copy of the catalog so that you can manually run
+          the `pacman-catalog <https://github.com/dylan-lang/pacman-catalog>`_
+          tests and submit a pull request. This eliminates a lot of
+          possibilities for making mistakes while editing the catalog by hand.
+
+This command may (as usual) be run from anywhere inside a workspace. Once
+you're satisfied that you're ready to release a new version of your package
+(tests pass, doc updated, etc.) follow these steps:
+
+#.  Update the ``"version"`` attribute in `dylan-package.json` to be the new
+    release's version, and commit the change.
+
+#.  Make a new release on GitHub with a tag that matches the release version.
+    For example, if the ``"version"`` attribute in `dylan-package.json` is
+    ``"0.5.0"`` the GitHub release should be tagged ``v0.5.0``.
+
+#.  Run ``dylan publish my-package``.  (If `pacman-catalog` isn't already an
+    active package in your workspace the command will abort and give you
+    instructions how to fix it.)
+
+#.  Commit the changes to `pacman-catalog
+    <https://github.com/dylan-lang/pacman-catalog>`_ and submit a pull request.
+    The tests to verify the catalog will be run automatically by the GitHub CI.
+
+#.  Once your PR has been merged, verify that the package is available in the
+    catalog by running ``dylan install my-package@0.5.0``, substituting your
+    new release name and version.
+
 dylan update
 ------------
 
-The `update` subcommand be be run from anywhere inside a workspace directory
+The `update` subcommand may be run from anywhere inside a workspace directory
 and performs two actions:
 
 #.  Installs all package dependencies, as specified in their

--- a/dylan-package.json
+++ b/dylan-package.json
@@ -1,6 +1,6 @@
 {
     "name": "dylan-tool",
-    "version": "0.4.1",
+    "version": "0.6.0",
     "category": "language-tools",
     "contact": "dylan-lang@googlegroups.com",
     "description": "Manage Dylan workspaces, packages, and registries",

--- a/library.dylan
+++ b/library.dylan
@@ -6,6 +6,7 @@ define library dylan-tool
   use common-dylan;
   use command-line-parser;
   use dylan-tool-commands;
+  use io;
   use logging;
   use system;
 end;
@@ -14,6 +15,7 @@ define module dylan-tool
   use common-dylan;
   use command-line-parser;
   use dylan-tool-commands;
+  use format-out;
   use logging;
   use operating-system, prefix: "os/";
 end;

--- a/pacman/packages.dylan
+++ b/pacman/packages.dylan
@@ -107,6 +107,8 @@ define method to-table
   let t = make(<istring-table>);
   t["version"] := version-to-string(release.release-version);
   t["dependencies"] := map-as(<vector>, dep-to-string, release.release-deps);
+  t["dev-dependencies"]
+    := map-as(<vector>, dep-to-string, release.release-dev-dependencies);
   // TODO: delete this after converting catalog
   t["deps"] := map-as(<vector>, dep-to-string, release.release-deps);
   t["url"] := release.release-url;
@@ -238,14 +240,16 @@ define function decode-dylan-package-json
                      contact: contact | "",
                      category: category | $uncategorized,
                      keywords: keywords);
-  make(<release>,
-       package: package,
-       version: version,
-       deps: deps,
-       dev-deps: dev-deps,
-       url: url,
-       license: license,
-       license-url: license-url)
+  let release = make(<release>,
+                     package: package,
+                     version: version,
+                     deps: deps,
+                     dev-deps: dev-deps,
+                     url: url,
+                     license: license,
+                     license-url: license-url);
+  add-release(package, release);
+  release
 end function;
 
 define generic package-name (o :: <object>) => (_ :: <string>);

--- a/workspaces/workspaces.dylan
+++ b/workspaces/workspaces.dylan
@@ -48,12 +48,12 @@ define function new
     end;
     log-info("Workspace created: %s", ws-path);
   end;
-  load-workspace(ws-dir)
+  load-workspace(directory: ws-dir)
 end function;
 
 // Update the workspace based on the workspace.json file or signal an error.
 define function update () => ()
-  let ws = load-workspace(fs/working-directory());
+  let ws = load-workspace();
   log-info("Workspace directory is %s.", ws.workspace-directory);
   let cat = pm/catalog();
   let (releases, actives) = update-deps(ws, cat);
@@ -82,7 +82,7 @@ end class;
 // `<workspace>` from it. `directory` defaults to the current working
 // directory.  Signals `<workspace-error>` if the file isn't found.
 define function load-workspace
-    (directory :: <directory-locator>) => (w :: <workspace>)
+    (#key directory :: <directory-locator> = fs/working-directory()) => (w :: <workspace>)
   let path = find-workspace-file(directory)
     | workspace-error("Workspace file not found for %s", directory);
   fs/with-open-file(stream = path, if-does-not-exist: #"signal")


### PR DESCRIPTION
This eliminates a lot of the potential for error in manually editing the
catalog, but still requires a few extra manual steps.

Incidentally fixes a bug in writing packages to the catalog. (Left out dev dependencies.)