### PR TITLE
Add all available options to dylan package file template.

### DIFF
--- a/sources/commands/new-library.dylan
+++ b/sources/commands/new-library.dylan
@@ -306,7 +306,11 @@ define constant $dylan-package-file-template
     "description": "YOUR DESCRIPTION HERE",
     "name": %=,
     "version": "0.1.0",
-    "url": "https://github.com/YOUR-ORG-HERE/YOUR-REPO-HERE"
+    "url": "https://github.com/YOUR-ORG-HERE/YOUR-REPO-HERE",
+    "keywords": [ ],
+    "contact": "",
+    "license": "",
+    "license-url": ""
 }
 ';
 


### PR DESCRIPTION
The user can see all available options to fill in the package, so there is no need to check the documentation.

Given that JSON does not allow comments inside the document, leave the options empty.