### PR TITLE
Updating uncommon-dylan

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/dylan-lang/regular-expressions
 [submodule "ext/uncommon-dylan"]
 	path = ext/uncommon-dylan
-	url = https://github.com/dylan-lang/uncommon-dylan
+	url = https://github.com/cgay/uncommon-dylan
 [submodule "ext/testworks"]
 	path = ext/testworks
 	url = https://github.com/dylan-lang/testworks

--- a/sources/library.dylan
+++ b/sources/library.dylan
@@ -32,7 +32,8 @@ define module shared
   use operating-system, prefix: "os/";
   use streams;
   use strings;
-  use uncommon-dylan;
+  use uncommon-dylan,
+    exclude: { format-out };
   export
     *debug?*,
     *verbose?*,
@@ -193,7 +194,7 @@ define module %workspaces
   use strings;
   use threads;
   use uncommon-dylan,
-    exclude: { format-to-string };
+    exclude: { format-out, format-to-string };
   use uncommon-utils,
     import: { err, iff, inc!, slice };
   use workspaces;
@@ -223,7 +224,7 @@ define module dylan-tool
   use streams;
   use strings;
   use uncommon-dylan,
-    exclude: { format-to-string };
+    exclude: { format-out, format-to-string };
   use uncommon-utils,
     import: { err, iff, inc!, slice };
   use workspaces, prefix: "ws/";


### PR DESCRIPTION
Truth be told, I want this because I want the newer uncommon-dylan in OD, which only comes in via dylan-tool, so I can use it to build protocol-buffers when adding protobuf support to the build system.