### PR TITLE
Add possible answers to ok-yes-no question prompt

### DIFF
--- a/sources/commands/publish.dylan
+++ b/sources/commands/publish.dylan
@@ -37,7 +37,7 @@ define method execute-subcommand
           name, pm/release-version(release), ws/$dylan-package-file-name);
     error(message);
   end;
-  if (yes-or-no?(format-to-string("About to publish %s, ok? ", release)))
+  if (yes-or-no?(format-to-string("About to publish %s, ok? [ok/yes/no]", release)))
     let file = pm/publish-release(cat, release);
     note("Package file written to %s. Commit the changes and submit a"
            " pull request.", file);


### PR DESCRIPTION
The users don't know what are the valid answers to the question, so they can press enter by default.