### PR TITLE
[doc] Integrate furo theme

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -12,7 +12,7 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../../ext/sphinx-extensions/sphinxcontrib'))
+sys.path.insert(0, os.path.abspath('../../_packages/sphinx-extensions/current/src/sphinxcontrib'))
 import dylan.themes as dylan_themes
 
 

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -12,13 +12,9 @@ The :program:`dylan` command-line tool
 * publishes packages to the Dylan package catalog.
 
 .. toctree::
-   :hidden:
+   :maxdepth: 2
 
    The pacman Package Manager <pacman>
-
-.. contents::
-   :depth: 2
-   :local:
 
 
 Terminology


### PR DESCRIPTION
- Remove `contents:` that create a conflict with ToC created by Furo theme
- Use sphinxcontrib from dylan-tool setup